### PR TITLE
Fix/cog unloading

### DIFF
--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -356,11 +356,17 @@ class Verify(commands.Cog):
     async def monitor_db_subroutine(self):
         """Monitor DB for changes"""
         try:
-            async for user in [i for i in db.queue.find() if i.get("verified")]:
-                await self.set_verified(user['discord']['id'])
-                await db.queue.find_one_and_delete(user["_id"])
+            logging.info("Monitoring DB")
+            async for change in db.queue.watch():
+                if change["operationType"] == "insert":
+                    user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
+                    if user.get("verified"):
+                        await self.set_verified(user['discord']['id'])
+                        await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
         except Exception as e:
             logging.error(f'ERROR MONITORING DB: {e}')
+            logging.warning('WAITING BEFORE TRYING AGAIN')
+            time.sleep(5)
 
     # Tasks
 

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -356,17 +356,11 @@ class Verify(commands.Cog):
     async def monitor_db_subroutine(self):
         """Monitor DB for changes"""
         try:
-            logging.info("Monitoring DB")
-            async for change in db.queue.watch():
-                if change["operationType"] == "insert":
-                    user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
-                    if user.get("verified"):
-                        await self.set_verified(user['discord']['id'])
-                        await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
+            async for user in [i for i in db.queue.find() if i.get("verified")]:
+                await self.set_verified(user['discord']['id'])
+                await db.queue.find_one_and_delete(user["_id"])
         except Exception as e:
             logging.error(f'ERROR MONITORING DB: {e}')
-            logging.warning('WAITING BEFORE TRYING AGAIN')
-            time.sleep(5)
 
     # Tasks
 

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -33,6 +33,9 @@ class Verify(commands.Cog):
         self.client = client
         self.monitor_db.start()
 
+    def cog_unload(self):
+        self.monitor_db.cancel()
+
     # Events
     @commands.Cog.listener()
     async def on_ready(self):

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -357,8 +357,7 @@ class Verify(commands.Cog):
     @tasks.loop(seconds=20)
     async def monitor_db(self):
         """Monitor DB for changes"""
-        queue = [i for i in db.queue.find()]
-        for user in [i for i in queue if i.get("verified")]:
+        for user in [i for i in db.queue.find() if i.get("verified")]:
             await self.set_verified(user['discord']['id'])
             await db.queue.find_one_and_delete(user["_id"])
 

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -376,7 +376,7 @@ class Verify(commands.Cog):
     @tasks.loop(seconds=20)
     async def monitor_db(self):
         """Monitor DB for changes"""
-        logging.info("Monitoring DB")
+        # logging.info("Monitoring DB")
         queue = [i for i in db.queue.find()]
         for user in [i for i in queue if i.get("verified")]:
             await self.set_verified(user['discord']['id'])

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -354,25 +354,33 @@ class Verify(commands.Cog):
 
     # Tasks
 
-    @tasks.loop()
+    # @tasks.loop()
+    # async def monitor_db(self):
+    #     """Monitor DB for changes"""
+    #     try:
+    #         logging.info("Monitoring DB")
+    #         async for change in db.queue.watch():
+    #             if change["operationType"] == "insert":
+    #                 user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
+
+    #                 if user.get("verified"):
+    #                     await self.set_verified(user['discord']['id'])
+
+    #                     await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
+
+    #     except Exception as e:
+    #         logging.error(f'ERROR MONITORING DB: {e}')
+    #         logging.warning('WAITING BEFORE TRYING AGAIN')
+    #         time.sleep(5)
+
+    @tasks.loop(seconds=20)
     async def monitor_db(self):
         """Monitor DB for changes"""
-        try:
-            logging.info("Monitoring DB")
-            async for change in db.queue.watch():
-                if change["operationType"] == "insert":
-                    user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
-
-                    if user.get("verified"):
-                        await self.set_verified(user['discord']['id'])
-
-                        await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
-
-        except Exception as e:
-            logging.error(f'ERROR MONITORING DB: {e}')
-            logging.warning('WAITING BEFORE TRYING AGAIN')
-            time.sleep(5)
-
+        logging.info("Monitoring DB")
+        queue = [i for i in db.queue.find()]
+        for user in [i for i in queue if i.get("verified")]:
+            await self.set_verified(user['discord']['id'])
+            await db.queue.find_one_and_delete(user["_id"])
 
 def setup(client):
     client.add_cog(Verify(client))

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -354,33 +354,33 @@ class Verify(commands.Cog):
 
     # Tasks
 
-    # @tasks.loop()
-    # async def monitor_db(self):
-    #     """Monitor DB for changes"""
-    #     try:
-    #         logging.info("Monitoring DB")
-    #         async for change in db.queue.watch():
-    #             if change["operationType"] == "insert":
-    #                 user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
-
-    #                 if user.get("verified"):
-    #                     await self.set_verified(user['discord']['id'])
-
-    #                     await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
-
-    #     except Exception as e:
-    #         logging.error(f'ERROR MONITORING DB: {e}')
-    #         logging.warning('WAITING BEFORE TRYING AGAIN')
-    #         time.sleep(5)
-
-    @tasks.loop(seconds=20)
+    @tasks.loop()
     async def monitor_db(self):
         """Monitor DB for changes"""
-        # logging.info("Monitoring DB")
-        queue = [i for i in db.queue.find()]
-        for user in [i for i in queue if i.get("verified")]:
-            await self.set_verified(user['discord']['id'])
-            await db.queue.find_one_and_delete(user["_id"])
+        # try:
+        logging.info("Monitoring DB")
+        async for change in db.queue.watch():
+            if change["operationType"] == "insert":
+                user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
+
+                if user.get("verified"):
+                    await self.set_verified(user['discord']['id'])
+
+                    await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
+
+        # except Exception as e:
+        #     logging.error(f'ERROR MONITORING DB: {e}')
+        #     logging.warning('WAITING BEFORE TRYING AGAIN')
+        #     time.sleep(5)
+
+    # @tasks.loop(seconds=20)
+    # async def monitor_db(self):
+    #     """Monitor DB for changes"""
+    #     # logging.info("Monitoring DB")
+    #     queue = [i for i in db.queue.find()]
+    #     for user in [i for i in queue if i.get("verified")]:
+    #         await self.set_verified(user['discord']['id'])
+    #         await db.queue.find_one_and_delete(user["_id"])
 
 def setup(client):
     client.add_cog(Verify(client))

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -354,33 +354,13 @@ class Verify(commands.Cog):
 
     # Tasks
 
-    @tasks.loop()
+    @tasks.loop(seconds=20)
     async def monitor_db(self):
         """Monitor DB for changes"""
-        # try:
-        logging.info("Monitoring DB")
-        async for change in db.queue.watch():
-            if change["operationType"] == "insert":
-                user = await db.users.find_one({"_id": change["fullDocument"]["ref"]})
-
-                if user.get("verified"):
-                    await self.set_verified(user['discord']['id'])
-
-                    await db.queue.find_one_and_delete({"_id": change["fullDocument"]['_id']})
-
-        # except Exception as e:
-        #     logging.error(f'ERROR MONITORING DB: {e}')
-        #     logging.warning('WAITING BEFORE TRYING AGAIN')
-        #     time.sleep(5)
-
-    # @tasks.loop(seconds=20)
-    # async def monitor_db(self):
-    #     """Monitor DB for changes"""
-    #     # logging.info("Monitoring DB")
-    #     queue = [i for i in db.queue.find()]
-    #     for user in [i for i in queue if i.get("verified")]:
-    #         await self.set_verified(user['discord']['id'])
-    #         await db.queue.find_one_and_delete(user["_id"])
+        queue = [i for i in db.queue.find()]
+        for user in [i for i in queue if i.get("verified")]:
+            await self.set_verified(user['discord']['id'])
+            await db.queue.find_one_and_delete(user["_id"])
 
 def setup(client):
     client.add_cog(Verify(client))

--- a/cogs/verify.py
+++ b/cogs/verify.py
@@ -352,7 +352,7 @@ class Verify(commands.Cog):
                 f"ERROR ADDING ROLE FOR {member.name}#{member.discriminator} IN {server.name}: {e}")
             return False
 
-    # Subroutine for the monitor_db task to avoid bare exceptions blocking sigterm
+    # Subroutine for the monitor_db task
     async def monitor_db_subroutine(self):
         """Monitor DB for changes"""
         try:


### PR DESCRIPTION
- Move DB task to subroutine
  This allows you to use bare exceptions without it locking the event loop on sig calls
- Use `db.collection.find()` instead of `db.collection.watch()`
  This also locks the event loop on sig calls
- Cancel task on cog unload
  This isn't entirely necessary and doesn't actually introduce any performance benefits, but it's good practice

Overall this reduces service kill time from 1m30s to 0-2 seconds