### PR TITLE
feat/react_report: Add message reporting by adding "⚠️" reaction

### DIFF
--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
         "notes",
         "mot",
         "usl",
-        "embedremover"
+        "embedremover",
+        "react_report"
     ],
     "flairs": {
         "3+": { "rid": "292033617461379084", "flairtext": "3+" },

--- a/unity_cogs/notes.py
+++ b/unity_cogs/notes.py
@@ -34,7 +34,7 @@ class Notes(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
-        print('Feedback cog online')
+        print('Notes cog online')
 
 # Commands
 

--- a/unity_cogs/react_report.py
+++ b/unity_cogs/react_report.py
@@ -1,0 +1,101 @@
+import sys
+import motor
+import logging
+import discord
+import datetime
+
+from discord.ext import commands
+from unity_util import bot_config
+
+
+mongo = motor.motor_asyncio.AsyncIOMotorClient(host=bot_config.MONGODB_HOST, port=int(
+    bot_config.MONGODB_PORT), replicaSet="rs01", username=bot_config.MONGODB_USERNAME, password=bot_config.MONGODB_PASSWORD, authSource=bot_config.MONGODB_DATABASE, authMechanism='SCRAM-SHA-1')
+db = mongo[bot_config.MONGODB_DATABASE]
+
+logging.basicConfig(level=logging.INFO, format="[%(levelname)s]\t %(name)s: %(message)s", handlers=[
+    logging.StreamHandler(sys.stdout),
+    logging.FileHandler(f'./logs/{bot_config.LOGGING_FILENAME}')
+])
+
+
+class ReactReport(commands.Cog):
+    def __init__(self, client):
+        self.client = client
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        logging.info("Reaction report cog online.")
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if payload.emoji.name != "⚠️":
+            return
+
+        # Get the message content (annoying)
+        guild = self.client.get_guild(payload.guild_id)
+
+        if not guild:
+            logging.warning(f"React Report: failed to fetch guild with ID {payload.guild_id}")
+            return
+
+        channel = guild.get_channel(payload.channel_id)
+
+        if not channel:
+            logging.warning(f"React Report: failed to fetch channel with ID {payload.channel_id}")
+            return
+
+        message = await channel.fetch_message(payload.message_id)
+
+        if not message:
+            logging.warning(f"React Report: failed to fetch message with ID {payload.message_id}")
+            return
+
+        report_channel = guild.get_channel(bot_config.REPORT_CHANNEL_ID)
+
+        if not report_channel:
+            logging.warning(f"React Report: failed to fetch report output channel with ID {bot_config.REPORT_CHANNEL_ID}")
+            return
+
+        cur_time = datetime.datetime.now()
+        timestamp = cur_time.strftime("%d/%m/%Y %H:%M:%S")
+
+        data = {
+            "message_id": payload.message_id,
+            "reporter_id": payload.user_id,
+            "channel_id": payload.channel_id,
+            "message_content": message.clean_content,
+            "report_timestamp": cur_time.utcfromtimestamp(0)
+        }
+
+        logging.info(f"Saving report data, message ID: {payload.message_id}")
+
+        save_success = await self.save_report_data(data)
+
+        if save_success:
+            await report_channel.send(embed=self.create_new_report_embed(message, payload, timestamp))
+
+    # Save report data to mongo
+    async def save_report_data(self, data: dict):
+        # Check if this message has been reported already.
+        # If so, then do nothing.
+        count = await db.reports.count_documents({"message_id": data["message_id"]})
+        if count > 0:
+            return False
+
+        await db.reports.insert_one(data)
+        return True
+
+    def create_new_report_embed(self, message: discord.Message, payload: discord.RawReactionActionEvent, timestamp: str):
+        # Fetch the user who reported the message.
+        member = message.guild.get_member(payload.user_id)
+
+        embed = discord.Embed(title="New report created", colour=discord.Colour.orange())
+        embed.description = message.clean_content
+        embed.add_field(name="Reporter", value=member.mention)
+        embed.add_field(name="Timestamp", value=timestamp)
+
+        return embed
+
+
+def setup(client):
+    client.add_cog(ReactReport(client))

--- a/unity_util/bot_config.py
+++ b/unity_util/bot_config.py
@@ -47,4 +47,6 @@ BUY_SELL_BACKUP_DM_CHANNEL_ID = int(get_env("BUY_SELL_BACKUP_DM_CHANNEL_ID", or_
 
 DVLA_API_KEY = get_env("DVLA_API_KEY", required=True)
 
+REPORT_CHANNEL_ID = int(get_env("REPORT_CHANNEL_ID", or_else="810214651433582633"))
+
 LOGGING_FILENAME = get_env("LOGGING_FILENAME", or_else=f'bot-{datetime.now().strftime("%m-%d-%Y-%H%M%S")}.log')


### PR DESCRIPTION
This PR enables users to report messages to moderators by adding a ⚠️ reaction to any message. It will save some information about the message to MongoDB, and create an embed in a moderator-only channel. If the message is removed or all ⚠️ reactions are removed, the information in the database is removed too.

<img width="341" alt="Screenshot 2021-02-13 at 19 12 36" src="https://user-images.githubusercontent.com/25872549/107859154-74618b00-6e2f-11eb-8344-10a5ca104ef3.png">
