### PR TITLE
Add CI workflows

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+max-line-length = 127
+extend-ignore = E203, W503, E501, F524, F523
+exclude =
+    .git
+    env
+    .github

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Black
 on: [push, pull_request]
 
 jobs:
-  lint:
+  black:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,13 @@
+name: Black
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+        with:
+          black_args: ". --check"

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -1,0 +1,28 @@
+name: Flake8
+
+on: [push, pull_request]
+
+jobs:
+  lint-flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository at the current branch
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8.5
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r requirements.txt
+      - name: Setup flake8 annotations
+        uses: rbialon/flake8-annotations@v1
+      - name: Lint with flake8
+        run: |
+					python3 -m pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+					python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+					# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+					python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -2,25 +2,30 @@ name: Flake8
 
 on: [push, pull_request]
 
-jobs:
-  lint-flake8:
+jobs: 
+  flake8: 
     runs-on: ubuntu-latest
-
-    steps:
-      # Checkout the repository at the current branch
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
+    steps: 
+      - 
+        uses: actions/checkout@v2
+      - 
+        name: "Set up Python 3.8"
         uses: actions/setup-python@v1
-        with:
-          python-version: 3.8.5
-      - name: Install dependencies
+        with: 
+          python-version: 3.8
+      - 
+        name: "Install dependencies"
         run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install -r requirements.txt
-          python3 -m pip install flake8
-      - name: Setup flake8 annotations
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+      - 
+        name: "Setup flake8 annotations"
         uses: rbialon/flake8-annotations@v1
-      - name: Lint with flake8
+      - 
+        name: "Lint with flake8"
         run: |
-					flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # stop the build if there are Python syntax errors or undefined names
-					flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+            pip install flake8
+            # stop the build if there are Python syntax errors or undefined names
+            flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+            # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+            flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -17,12 +17,10 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install -r requirements.txt
+          python3 -m pip install flake8
       - name: Setup flake8 annotations
         uses: rbialon/flake8-annotations@v1
       - name: Lint with flake8
         run: |
-					python3 -m pip install flake8
-          # stop the build if there are Python syntax errors or undefined names
-					python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-					# exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-					python3 -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+					flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # stop the build if there are Python syntax errors or undefined names
+					flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide

--- a/README.md
+++ b/README.md
@@ -2,34 +2,37 @@
 
 ## Deployment requirements
 
-- discord.py
-- systemd
 - MongoDB
-- pymongo
-- motor
-- praw
 - Python >= 3.7
 
 ## Environment variables
 
-| Name | Purpose | Required | Default value |
-|---|---|---|---|
-| `MONGODB_HOST` | The hostname of the MongoDB instance to connect to | No | `127.0.0.1` |
-| `MONGODB_PORT` | The port on which the MongoDB instance is listening | No | `27017` |
-| `MONGODB_USERNAME` | The username with which to authenticate with MongoDB | Yes | |
-| `MONGODB_PASSWORD` | The password with which to authenticate with MongoDB | Yes | |
-| `MONGODB_DATABASE` | The name of the database in MongoDB to read/write data | No | `hwsuk` |
-| `DISCORD_SERVER_ID` | The server ID that is checked when modifying roles or searching for members | Yes | |
-| `PRAW_CLIENT_ID` | The client ID for the application used for PRAW queries | Yes | |
-| `PRAW_CLIENT_SECRET` | The client secret for the application used for PRAW queries | Yes | |
-| `PRAW_PASSWORD` | The password for the user used for PRAW queries | Yes | |
-| `PRAW_USER_AGENT` | The user agent sent to Reddit when making PRAW queries | No | `Checks if users are banned for our synced discord and keeps flairs synced` |
-| `PRAW_USERNAME` | The username of the user used for PRAW queries | No | `HWSUKMods` |
-| `REACTION_CHANNEL_ID` | The channel ID used for feedback | Yes | |
-| `MOD_CHANNEL_ID` | The channel ID used for mod notifications of feedback items | Yes | |
-| `REACTION_THRESHOLD` | Determines how many upvotes a feedback submission needs before it is sent to the mods | Yes | |
-| `BUY_SELL_CHANNEL_ID` | The channel ID used for removing too frequent posts | Yes | |
-| `BUY_SELL_BACKUP_DM_CHANNEL_ID` | The channel ID used for notifying users of removed posts if they have DMs disabled | No | `292032782409007115` |
-| `BUY_SELL_LIMIT_SECONDS` | The number of seconds that each user post is limited to | Yes | `259200` |
-| `DVLA_API_KEY` | Key for the DVLA API | Yes | |
-| `LOGGING_FILENAME` | Determines the naming format used for log files | No | `f'bot-{datetime.now().strftime("%m-%d-%Y-%H%M%S")}.log'` |
+| Name                            | Purpose                                                                               | Required | Default value                                                               |
+| ------------------------------- | ------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------- |
+| `MONGODB_HOST`                  | The hostname of the MongoDB instance to connect to                                    | No       | `127.0.0.1`                                                                 |
+| `MONGODB_PORT`                  | The port on which the MongoDB instance is listening                                   | No       | `27017`                                                                     |
+| `MONGODB_USERNAME`              | The username with which to authenticate with MongoDB                                  | Yes      |                                                                             |
+| `MONGODB_PASSWORD`              | The password with which to authenticate with MongoDB                                  | Yes      |                                                                             |
+| `MONGODB_DATABASE`              | The name of the database in MongoDB to read/write data                                | No       | `hwsuk`                                                                     |
+| `DISCORD_SERVER_ID`             | The server ID that is checked when modifying roles or searching for members           | Yes      |                                                                             |
+| `PRAW_CLIENT_ID`                | The client ID for the application used for PRAW queries                               | Yes      |                                                                             |
+| `PRAW_CLIENT_SECRET`            | The client secret for the application used for PRAW queries                           | Yes      |                                                                             |
+| `PRAW_PASSWORD`                 | The password for the user used for PRAW queries                                       | Yes      |                                                                             |
+| `PRAW_USER_AGENT`               | The user agent sent to Reddit when making PRAW queries                                | No       | `Checks if users are banned for our synced discord and keeps flairs synced` |
+| `PRAW_USERNAME`                 | The username of the user used for PRAW queries                                        | No       | `HWSUKMods`                                                                 |
+| `REACTION_CHANNEL_ID`           | The channel ID used for feedback                                                      | Yes      |                                                                             |
+| `MOD_CHANNEL_ID`                | The channel ID used for mod notifications of feedback items                           | Yes      |                                                                             |
+| `REACTION_THRESHOLD`            | Determines how many upvotes a feedback submission needs before it is sent to the mods | Yes      |                                                                             |
+| `BUY_SELL_CHANNEL_ID`           | The channel ID used for removing too frequent posts                                   | Yes      |                                                                             |
+| `BUY_SELL_BACKUP_DM_CHANNEL_ID` | The channel ID used for notifying users of removed posts if they have DMs disabled    | No       | `292032782409007115`                                                        |
+| `BUY_SELL_LIMIT_SECONDS`        | The number of seconds that each user post is limited to                               | Yes      | `259200`                                                                    |
+| `DVLA_API_KEY`                  | Key for the DVLA API                                                                  | Yes      |                                                                             |
+| `LOGGING_FILENAME`              | Determines the naming format used for log files                                       | No       | `f'bot-{datetime.now().strftime("%m-%d-%Y-%H%M%S")}.log'`                   |
+
+## Contributing to this project
+
+Please run black before committing code to this repo
+
+```py
+python3 -m black .
+```

--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,6 @@ from discord.ext import commands
 
 from unity_util import bot_config
 
-
 logging.basicConfig(
     level=logging.INFO,
     format="[%(levelname)s]\t %(name)s: %(message)s",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[tool.black]
+line-length = 127
+target-version = ['py38']
+exclude = 'env'
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 127
+skip = "env"
+profile = "black"
+
+[tool.pylint.messages_control]
+disable = "C0330, C0326"
+
+[tool.pylint.format]
+max-line-length = "127"

--- a/unity_cogs/cex.py
+++ b/unity_cogs/cex.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import urllib.parse
 from typing import Tuple
 from urllib import parse
@@ -8,9 +7,7 @@ import discord
 import httpx
 from discord.ext import commands
 
-import unity_util.bot_config as bot_config
 from unity_util.menu import DEFAULT_CONTROLS, menu
-
 
 CEX_RED = 0xFF0000
 CEX_LOGO = "https://uk.webuy.com/_nuxt/74714aa39f40304c8fac8e7520cc0a35.png"
@@ -88,16 +85,8 @@ class Cex(commands.Cog):
             await ctx.send(embed=cex_embed)
             return
 
-        cex_embeds = [
-            self.make_cex_embed(item, f"{i + 1} of {len(cex_search)}")
-            for i, item in enumerate(cex_search)
-        ]
-        await menu(
-            ctx,
-            pages=cex_embeds,
-            controls=DEFAULT_CONTROLS,
-            timeout=180.0
-        )
+        cex_embeds = [self.make_cex_embed(item, f"{i + 1} of {len(cex_search)}") for i, item in enumerate(cex_search)]
+        await menu(ctx, pages=cex_embeds, controls=DEFAULT_CONTROLS, timeout=180.0)
 
     # Helper functions
 
@@ -161,7 +150,10 @@ class Cex(commands.Cog):
         return embed
 
     async def no_results(self, ctx, search_term: str):
-        embed = discord.Embed(colour=CEX_RED, description=f"No products found for `{search_term.replace('`', '``')}`",)
+        embed = discord.Embed(
+            colour=CEX_RED,
+            description=f"No products found for `{search_term.replace('`', '``')}`",
+        )
         embed.set_author(name="No results 🙁", icon_url=CEX_LOGO)
         await ctx.send(embed=embed)
 

--- a/unity_cogs/ebay.py
+++ b/unity_cogs/ebay.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import math
 import re
 from datetime import datetime as dt
@@ -196,7 +197,8 @@ class Ebay(commands.Cog):
                 "ended_date": d["ended_date"],
                 "id": str(d["id"]),
             }
-        except:
+        except Exception as error:
+            logging.error(f"Error getting product info: {error}")
             return {}
 
     def parse_price(self, product):

--- a/unity_cogs/limiter.py
+++ b/unity_cogs/limiter.py
@@ -110,7 +110,7 @@ class Limiter(commands.Cog):
 
         try:
             await dm_channel.send(content, embed=embed)
-        except:  # If the bot can't DM the user
+        except discord.Forbidden:  # If the bot can't DM the user
             backup_channel = self.client.get_channel(bot_config.BUY_SELL_BACKUP_DM_CHANNEL_ID)
             content = f"<@{author.id}> {content}"
             await backup_channel.send(content=content, embed=embed)

--- a/unity_cogs/rendermeme.py
+++ b/unity_cogs/rendermeme.py
@@ -3,7 +3,6 @@ import random
 
 from discord.ext import commands
 
-
 IMAGE_LINKS = [
     "https://cdn.discordapp.com/attachments/292035708779102208/800403298096119848/eae418cc13c3a477777624169021de320caca7a2827e2dfaf2af21d00f8b1780_1.png",
     "https://tenor.com/view/who-tf-asked-nasas-radar-dish-who-asked-nobody-asked-gif-17675657",

--- a/unity_cogs/usl.py
+++ b/unity_cogs/usl.py
@@ -1,13 +1,11 @@
 import logging
 import re
-import sys
 
 import discord
 from discord.ext import commands
 
 from unity_services import universal_scammer_list as usl
 from unity_util.embed_helper import error_message
-
 
 EMBED_BANNED_COLOUR = 0xB00E0E
 EMBED_NOT_BANNED_COLOUR = 0x3CB00E
@@ -39,7 +37,7 @@ class UniversalScammerList(commands.Cog):
             await error_message(
                 ctx,
                 "Invalid username format. Reddit usernames can consist of alphanumeric characters, hyphens and underscores only.",
-                cmd_error=False
+                cmd_error=False,
             )
             return
 
@@ -52,7 +50,7 @@ class UniversalScammerList(commands.Cog):
             logging.warning(f"Error while querying USL API: {error}")
             await error_message(
                 ctx,
-                "Something went wrong while querying the USL database. Please try again later, or contact the moderators for assistance."
+                "Something went wrong while querying the USL database. Please try again later, or contact the moderators for assistance.",
             )
 
     def make_embed(self, data: dict) -> discord.Embed:

--- a/unity_cogs/verify.py
+++ b/unity_cogs/verify.py
@@ -10,8 +10,8 @@ from discord.ext import commands, tasks
 from unity_services import universal_scammer_list as usl
 from unity_util import bot_config
 from unity_util.bot_config import db
-from unity_util.menu import yes_or_no
 from unity_util.embed_helper import error_message
+from unity_util.menu import yes_or_no
 
 reddit = praw.Reddit(
     client_id=bot_config.PRAW_CLIENT_ID,

--- a/unity_util/embed_helper.py
+++ b/unity_util/embed_helper.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 async def error_message(ctx: commands.Context, error_msg: str, cmd_error: bool = True):
     """Send an error message to the channel"""
     embed = discord.Embed(
-        title=f"Error",
+        title="Error",
         description=f"Error in command {ctx.command.name}: `{error_msg}`" if cmd_error else error_msg,
         colour=discord.Colour.red(),
     )


### PR DESCRIPTION
Workflows added:
- black
- flake8

Both Workflows apply annotations to a diff
I've added `.flake8` and `pyproject.toml` files to assist in linting configuration. This is not only for the benefit of the workflows, but also for people working on the codebase. For example, I've added scopes for pylint and isort, even though they're not used here. This is so that anyone using these tools will have a config that adheres to the same config as the linters we are using in our workflows.

I'm merging this to the refactor branch because it includes a number of cleanups that would only be applicable to the refactor branch. There's little point in merging to a branch that will fail the tests (master) when you've already fixed those errors in a refactor IMO

Closes #46